### PR TITLE
原来使用surfaceTexture的方式在vivox3l上退出会有崩溃,现对逻辑进行了调整

### DIFF
--- a/demo/src/net/qyvideo/qianyiplayer/PlayerUseTextureView.java
+++ b/demo/src/net/qyvideo/qianyiplayer/PlayerUseTextureView.java
@@ -345,12 +345,9 @@ public class PlayerUseTextureView extends Activity implements  TextureView.Surfa
     @Override
     protected void onDestroy(){
         super.onDestroy();
-        if(mSurfaceTexture != null)
-            mSurfaceTexture.release();
 
         mVideoTextureView = null;
         mSurfaceTexture = null;
-
     }
     @Override
     protected void onPause() {
@@ -488,6 +485,7 @@ public class PlayerUseTextureView extends Activity implements  TextureView.Surfa
         }
 
         mHandler = null;
+        mSurfaceTexture = null;
 
         finish();
     }
@@ -559,7 +557,7 @@ public class PlayerUseTextureView extends Activity implements  TextureView.Surfa
 
     @Override
     public boolean onSurfaceTextureDestroyed(SurfaceTexture surface) {
-        return  false;
+        return (mSurfaceTexture == null);
     }
 
     @Override


### PR DESCRIPTION
验证发现在vivo手机上退出调用surfacetexture release函数会有崩溃问题，目前对逻辑进行了调整。
@FirmianaRain @fpzeng 